### PR TITLE
Remove ClientID/ChargeableUserIdentity log property

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"strings"
 
 	"github.com/google/uuid"
 )
@@ -41,34 +40,4 @@ func SessionIdFromBytes(val []byte) uuid.NullUUID {
 	}
 
 	return uuid.NullUUID{}
-}
-
-func ParseTextID(val string) (string, error) {
-
-	if val = strings.TrimSpace(val); val == "" {
-		return "", errors.New("empty value")
-	}
-
-	for _, char := range val {
-
-		switch char {
-		case '-', '_':
-			continue
-		}
-
-		switch {
-
-		case char >= '0' && char <= '9':
-			continue
-		case char >= 'A' && char <= 'Z':
-			continue
-		case char >= 'a' && char <= 'z':
-			continue
-
-		default:
-			return "", errors.New("unexpected character")
-		}
-	}
-
-	return val, nil
 }

--- a/auth/radius.go
+++ b/auth/radius.go
@@ -20,7 +20,6 @@ import (
 	"github.com/maddsua/layeh-radius/rfc2866"
 	"github.com/maddsua/layeh-radius/rfc3162"
 	"github.com/maddsua/layeh-radius/rfc3576"
-	"github.com/maddsua/layeh-radius/rfc4372"
 	"github.com/maddsua/layeh-radius/rfc4679"
 	"github.com/maddsua/layeh-radius/rfc5580"
 	"github.com/maddsua/layeh-radius/rfc6911"
@@ -376,7 +375,6 @@ func (this *radiusController) WithPassword(ctx context.Context, auth PasswordAut
 		slog.String("method", "passwd"),
 		slog.String("username", auth.Username),
 		slog.String("sid", sess.ID.String()),
-		slog.String("user", sess.ClientID),
 		slog.Int("dl", sess.Traffic.ActualRateRx),
 		slog.Int("up", sess.Traffic.ActualRateTx),
 		slog.Int("max_dl", sess.Traffic.MaximumRateRx),
@@ -451,7 +449,6 @@ func (this *radiusController) authRequestAccess(ctx context.Context, auth Passwo
 	sess := Session{
 		ID:       sessUuid,
 		UserName: &auth.Username,
-		ClientID: "<nil>",
 
 		FramedIP: auth.NasAddr,
 
@@ -459,16 +456,6 @@ func (this *radiusController) authRequestAccess(ctx context.Context, auth Passwo
 
 		lastActivity: time.Now(),
 		lastUpdated:  time.Now(),
-	}
-
-	if val := rfc4372.ChargeableUserIdentity_Get(resp); len(val) > 0 {
-		if uid, err := uuid.FromBytes(val); err == nil {
-			sess.ClientID = uid.String()
-		} else if uid, err := uuid.Parse(string(val)); err == nil {
-			sess.ClientID = uid.String()
-		} else if uid, err := ParseTextID(string(val)); err == nil {
-			sess.ClientID = uid
-		}
 	}
 
 	if addr := rfc2865.FramedIPAddress_Get(resp); addr != nil {

--- a/auth/session.go
+++ b/auth/session.go
@@ -15,7 +15,6 @@ import (
 type Session struct {
 	ID       uuid.UUID
 	UserName *string
-	ClientID string
 
 	//	An outbound IP assigned to this session
 	FramedIP net.IP

--- a/cmd/vx-static-auth/radius.go
+++ b/cmd/vx-static-auth/radius.go
@@ -61,7 +61,7 @@ func (this authenticator) ServeRADIUS(w radius.ResponseWriter, req *radius.Reque
 	if user.ProxyAddr != "" && user.ProxyAddr != nasIP.String() {
 		w.Write(req.Response(radius.CodeAccessReject))
 		slog.Info("Auth: Rejected: ProxyAddr denied",
-			slog.String("nas_addr", req.RemoteAddr.String()),
+			slog.String("nas_ip", req.RemoteAddr.String()),
 			slog.String("username", username),
 			slog.String("password", password),
 			slog.String("client_ip", clientIP.String()),
@@ -73,7 +73,7 @@ func (this authenticator) ServeRADIUS(w radius.ResponseWriter, req *radius.Reque
 	if user.ProxyPort != 0 && user.ProxyPort != int(nasPort) {
 		w.Write(req.Response(radius.CodeAccessReject))
 		slog.Info("Auth: Rejected: Port denied",
-			slog.String("nas_addr", req.RemoteAddr.String()),
+			slog.String("nas_ip", req.RemoteAddr.String()),
 			slog.String("username", username),
 			slog.String("password", password),
 			slog.String("client_ip", clientIP.String()),
@@ -84,7 +84,7 @@ func (this authenticator) ServeRADIUS(w radius.ResponseWriter, req *radius.Reque
 
 	resp := req.Response(radius.CodeAccessAccept)
 	slog.Info("Auth: Accepted",
-		slog.String("nas_addr", req.RemoteAddr.String()),
+		slog.String("nas_ip", req.RemoteAddr.String()),
 		slog.String("username", username),
 		slog.String("password", password),
 		slog.String("client_ip", clientIP.String()),


### PR DESCRIPTION
Closes #66 

This radius attribute isn't used anywhere except for logging and that alone isn't enough of the reason to keep it spamming my log stream
