### PR TITLE
Feat: Restart proxy services if their options have changed

### DIFF
--- a/http/http_proxy.go
+++ b/http/http_proxy.go
@@ -28,7 +28,7 @@ func (opts HttpServiceOptions) String() string {
 	return fmt.Sprintf("forward=%v", opts.HttpForwardEnabled)
 }
 
-func (opts HttpServiceOptions) AllowMethodList() []string {
+func (opts HttpServiceOptions) allowMethodList() []string {
 
 	methods := []string{http.MethodConnect}
 
@@ -44,7 +44,7 @@ func (opts HttpServiceOptions) AllowMethodList() []string {
 	return methods
 }
 
-func (opts HttpServiceOptions) MethodAllowed(method string) bool {
+func (opts HttpServiceOptions) methodAllowed(method string) bool {
 
 	switch method {
 	case http.MethodConnect:
@@ -183,21 +183,21 @@ func (handler *requestHandler) ServeHTTP(wrt http.ResponseWriter, req *http.Requ
 
 	if req.Method == http.MethodOptions {
 
-		wrt.Header().Set("Allow", strings.Join(handler.AllowMethodList(), ", "))
+		wrt.Header().Set("Allow", strings.Join(handler.allowMethodList(), ", "))
 		wrt.Header().Set("Proxy-Authenticate", "Basic")
 		wrt.WriteHeader(http.StatusNoContent)
 
 		return
 	}
 
-	if !handler.MethodAllowed(req.Method) {
+	if !handler.methodAllowed(req.Method) {
 
 		slog.Debug("HTTP: ServeHTTP: Method not allowed",
 			slog.String("proxy_addr", req.Host),
 			slog.String("peer_addr", req.RemoteAddr),
 			slog.String("method", req.Method))
 
-		wrt.Header().Set("Allow", strings.Join(handler.AllowMethodList(), ", "))
+		wrt.Header().Set("Allow", strings.Join(handler.allowMethodList(), ", "))
 		wrt.Header().Set("Proxy-Connection", "Close")
 		wrt.WriteHeader(http.StatusMethodNotAllowed)
 

--- a/http/http_proxy.go
+++ b/http/http_proxy.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -17,6 +18,14 @@ const ServiceType = "http"
 
 type HttpServiceOptions struct {
 	HttpForwardEnabled bool `json:"http_forward_enabled" yaml:"http_forward_enabled"`
+}
+
+func (opts HttpServiceOptions) ProxyService() string {
+	return ServiceType
+}
+
+func (opts HttpServiceOptions) String() string {
+	return fmt.Sprintf("forward=%v", opts.HttpForwardEnabled)
 }
 
 func (opts HttpServiceOptions) AllowMethodList() []string {
@@ -112,6 +121,10 @@ func (svc *httpService) BindAddr() net.Addr {
 	}
 
 	return &net.TCPAddr{IP: hostIp, Port: portNumber}
+}
+
+func (svc *httpService) Options() proxyd.ProxyServiceOptions {
+	return svc.handler.HttpServiceOptions
 }
 
 func (svc *httpService) serve(listener net.Listener) {

--- a/proxy_service.go
+++ b/proxy_service.go
@@ -8,7 +8,13 @@ import (
 type ProxyService interface {
 	ProxyService() string
 	BindAddr() net.Addr
+	Options() ProxyServiceOptions
 	Shutdown(ctx context.Context) error
+}
+
+type ProxyServiceOptions interface {
+	ProxyService() string
+	String() string
 }
 
 type ServiceManager interface {

--- a/proxytable/table_orchestrator.go
+++ b/proxytable/table_orchestrator.go
@@ -198,8 +198,8 @@ func (orch *Orchestrator) RefreshTable(ctx context.Context, services []ProxyServ
 
 		slot := orch.slots[bindKey]
 
-		// repalce slot if it's empty or if it's service is incompatible
-		if slot == nil || slot.svc == nil || slot.svc.ProxyService() != entry.Service {
+		// repalce slot if it isn't up to date
+		if !slot.Satisfies(entry.ProxyServiceOptions) {
 
 			if slot == nil {
 

--- a/proxytable/table_slot.go
+++ b/proxytable/table_slot.go
@@ -16,6 +16,22 @@ type serviceSlot struct {
 	err  error
 }
 
+func (slot *serviceSlot) Satisfies(opts ProxyServiceOptions) bool {
+
+	if slot == nil || slot.svc == nil || slot.err != nil {
+		return false
+	} else if slot.svc.ProxyService() != opts.Service {
+		return false
+	}
+
+	switch active := slot.svc.Options().(type) {
+	case http_pkg.HttpServiceOptions:
+		return active.String() == opts.HttpServiceOptions.String()
+	}
+
+	return true
+}
+
 func (slot *serviceSlot) Shutdown(ctx context.Context) error {
 
 	// forcing a slot to shut down anyway after a 3 second wait period;

--- a/socks/socks_proxy.go
+++ b/socks/socks_proxy.go
@@ -52,6 +52,10 @@ func (svc *socksService) BindAddr() net.Addr {
 	return svc.listener.Addr()
 }
 
+func (svc *socksService) Options() proxyd.ProxyServiceOptions {
+	return nil
+}
+
 func (svc *socksService) serve() {
 
 	for svc.ctx.Err() == nil {


### PR DESCRIPTION
Lets you restart a service if the options such as, for instance, TLS certificates, have been changed